### PR TITLE
Feature/steelai 771

### DIFF
--- a/linux/drivers/ptp/ptp_clockmatrix.c
+++ b/linux/drivers/ptp/ptp_clockmatrix.c
@@ -2436,8 +2436,13 @@ static int idtcm_probe(struct platform_device *pdev)
 
 	err = idtcm_load_firmware(idtcm, &pdev->dev);
 
-	if (err)
+	if (err) {
+		if (err == -ENOENT) {
+			mutex_unlock(idtcm->lock);
+			return -EPROBE_DEFER;
+		}
 		dev_warn(idtcm->dev, "loading firmware failed with %d", err);
+	}
 
 	wait_for_chip_ready(idtcm);
 


### PR DESCRIPTION
[STEELAI-771] cm: Return EPROBE_DEFER if load firmware fails with ENOENT
[STEELAI-767] Fix - use 'max_adj' value in phase pull-in's max_ffo_ppb instead of 0

